### PR TITLE
Refactor to have more input nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,6 +29,7 @@ repos:
     exclude: &exclude_files >
       (?x)^(
           docs/.*|
+          examples/*|
       )$
     entry: pylint
 

--- a/examples/example_LLG.py
+++ b/examples/example_LLG.py
@@ -14,7 +14,8 @@ from aiida.orm import Dict
 import numpy as np
 
 INPUT_DIR = path.join(path.dirname(path.realpath(__file__)), 'input_files')
-OUTPUT_DIR = path.join(path.dirname(path.realpath(__file__)), 'output_files/temperature_spins.txt')
+OUTPUT_DIR = path.join(path.dirname(path.realpath(__file__)),
+                       'output_files/temperature_spins.txt')
 
 
 def test_run(spirit_code):
@@ -32,14 +33,16 @@ def test_run(spirit_code):
     inputs['code'] = spirit_code
     # prepare parameters
     output_contents = ''
-    for i in range(0,1051,50):
+    for i in range(0, 1051, 50):
         parameters = Dict(
             dict={
                 'llg_temperature': str(i),  # temperature noise (in K)
-                'external_field_magnitude': '0.005',  # external field of 0.005 T
+                'external_field_magnitude':
+                '0.005',  # external field of 0.005 T
                 'external_field_normal':
                 '0.0 0.0 1.0',  # external field points in z direction
-                'mu_s': '2.2',  # change spin moment to have the right size for Fe
+                'mu_s':
+                '2.2',  # change spin moment to have the right size for Fe
                 'llg_n_iterations': '200000'  # limit the number of iterations
             })
         inputs['parameters'] = parameters
@@ -58,9 +61,8 @@ def test_run(spirit_code):
         mag_mean = np.mean(spins_final, axis=0)
         output_contents += str(i) + '\t' + str(mag_mean[2]) + '\n'
 
-    with open (OUTPUT_DIR, 'w') as output_file:
+    with open(OUTPUT_DIR, 'w') as output_file:
         output_file.write(output_contents)
-
 
 
 @click.command()

--- a/examples/example_LLG.py
+++ b/examples/example_LLG.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+# pylint: disable=duplicate-code
 """Run a test calculation on localhost.
 
-Usage: ./example_01.py
+Usage: ./example_LLG.py
 """
+
 from os import path
 import click
+import numpy as np
 from aiida import cmdline, engine
+from aiida.orm import Dict
 from aiida.plugins import CalculationFactory
 from aiida_spirit import helpers
 from aiida_spirit.helpers import prepare_test_inputs
-from aiida.orm import Dict
-import numpy as np
 
 INPUT_DIR = path.join(path.dirname(path.realpath(__file__)), 'input_files')
-OUTPUT_DIR = path.join(path.dirname(path.realpath(__file__)),
-                       'output_files/temperature_spins.txt')
 
 
 def test_run(spirit_code):
@@ -28,41 +28,41 @@ def test_run(spirit_code):
         computer = helpers.get_computer()
         spirit_code = helpers.get_code(entry_point='spirit', computer=computer)
 
+    # use template input, prepared for a simple bcc Fe example
     inputs = prepare_test_inputs(INPUT_DIR)
+
     # add the spirit code to the inputs
     inputs['code'] = spirit_code
+
     # prepare parameters
-    output_contents = ''
-    for i in range(0, 1051, 50):
-        parameters = Dict(
-            dict={
-                'llg_temperature': str(i),  # temperature noise (in K)
-                'external_field_magnitude':
-                '0.005',  # external field of 0.005 T
-                'external_field_normal':
-                '0.0 0.0 1.0',  # external field points in z direction
-                'mu_s':
-                '2.2',  # change spin moment to have the right size for Fe
-                'llg_n_iterations': '200000'  # limit the number of iterations
-            })
-        inputs['parameters'] = parameters
+    parameters = Dict(
+        dict={
+            # temperature noise (in K)
+            'llg_temperature': '50',
+            # external field of 5 mT
+            'external_field_magnitude': '0.005',
+            # external field points in z direction
+            'external_field_normal': '0.0 0.0 1.0',
+            # change spin moment to have the right size for Fe
+            'mu_s': '2.2',
+            # limit the number of iterations
+            'llg_n_iterations': '200000'
+        })
+    inputs['parameters'] = parameters
 
-        # Note: in order to submit your calculation to the aiida daemon, do:
-        # from aiida.engine import submit
-        # future = submit(CalculationFactory('spirit'), **inputs)
-        result = engine.run(CalculationFactory('spirit'), **inputs)
+    # Note: in order to submit your calculation to the aiida daemon, do:
+    # from aiida.engine import submit
+    # future = submit(CalculationFactory('spirit'), **inputs)
+    result = engine.run(CalculationFactory('spirit'), **inputs)
 
-        #computed_diff = result['spirit'].get_content()
-        print(f'Computed result: {result}')
+    print(f'Computed result: {result}')
 
-        ret = result['retrieved']
-        with ret.open('spirit_Image-00_Spins-final.ovf') as _file:
-            spins_final = np.loadtxt(_file)
-        mag_mean = np.mean(spins_final, axis=0)
-        output_contents += str(i) + '\t' + str(mag_mean[2]) + '\n'
+    ret = result['retrieved']
+    with ret.open('spirit_Image-00_Spins-final.ovf') as _file:
+        spins_final = np.loadtxt(_file)
+    mag_mean = np.mean(spins_final, axis=0)
 
-    with open(OUTPUT_DIR, 'w') as output_file:
-        output_file.write(output_contents)
+    print(f'mean magnetization direction: {mag_mean}')
 
 
 @click.command()
@@ -71,11 +71,11 @@ def test_run(spirit_code):
 def cli(code):
     """Run example.
 
-    Example usage: $ ./example_01.py --code diff@localhost
+    Example usage: $ ./example_LLG.py --code spirit@localhost
 
-    Alternative (creates diff@localhost-test code): $ ./example_01.py
+    Alternative (creates spirit@localhost-test code): $ ./example_LLG.py
 
-    Help: $ ./example_01.py --help
+    Help: $ ./example_LLG.py --help
     """
     test_run(code)
 

--- a/examples/example_Tc_scan_LLG.py
+++ b/examples/example_Tc_scan_LLG.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# pylint: disable=duplicate-code
+"""Run a test calculation on localhost.
+
+Usage: ./example_01.py
+"""
+
+from os import path
+import click
+import numpy as np
+from aiida import cmdline, engine
+from aiida.orm import Dict
+from aiida.plugins import CalculationFactory
+from aiida_spirit import helpers
+from aiida_spirit.helpers import prepare_test_inputs
+
+INPUT_DIR = path.join(path.dirname(path.realpath(__file__)), 'input_files')
+OUTPUT_DIR = path.join(path.dirname(path.realpath(__file__)),
+                       'output_files/temperature_spins.txt')
+
+
+def test_run(spirit_code):
+    """Run a calculation on the localhost computer.
+
+    Uses test helpers to create AiiDA Code on the fly.
+    """
+    if not spirit_code:
+        # get code
+        computer = helpers.get_computer()
+        spirit_code = helpers.get_code(entry_point='spirit', computer=computer)
+
+    inputs = prepare_test_inputs(INPUT_DIR)
+    # add the spirit code to the inputs
+    inputs['code'] = spirit_code
+    # prepare parameters
+    output_contents = ''
+    for i in range(0, 1051, 50):
+        parameters = Dict(
+            dict={
+                'llg_temperature': str(i),  # temperature noise (in K)
+                'external_field_magnitude':
+                '0.005',  # external field of 0.005 T
+                'external_field_normal':
+                '0.0 0.0 1.0',  # external field points in z direction
+                'mu_s':
+                '2.2',  # change spin moment to have the right size for Fe
+                'llg_n_iterations': '200000'  # limit the number of iterations
+            })
+        inputs['parameters'] = parameters
+
+        # Note: in order to submit your calculation to the aiida daemon, do:
+        # from aiida.engine import submit
+        # future = submit(CalculationFactory('spirit'), **inputs)
+        result = engine.run(CalculationFactory('spirit'), **inputs)
+
+        #computed_diff = result['spirit'].get_content()
+        print(f'Computed result: {result}')
+
+        ret = result['retrieved']
+        with ret.open('spirit_Image-00_Spins-final.ovf') as _file:
+            spins_final = np.loadtxt(_file)
+        mag_mean = np.mean(spins_final, axis=0)
+        output_contents += str(i) + '\t' + str(mag_mean[2]) + '\n'
+
+    with open(OUTPUT_DIR, 'w') as output_file:
+        output_file.write(output_contents)
+
+
+@click.command()
+@cmdline.utils.decorators.with_dbenv()
+@cmdline.params.options.CODE()
+def cli(code):
+    """Run example.
+
+    Example usage: $ ./example_01.py --code diff@localhost
+
+    Alternative (creates diff@localhost-test code): $ ./example_01.py
+
+    Help: $ ./example_01.py --help
+    """
+    test_run(code)
+
+
+if __name__ == '__main__':
+    cli()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Add a `run_options` input node that allows to control the spirit run (i.e. what goes into the `run_spirit.py` script).
This input can be used to choose the calculation mode (so far only LLG) and the solver (so far only Dupondt) and it allows to control the initial state before the calculation starts (so far eith use random configuration or align spins in +z).

Also fix pre-commit